### PR TITLE
Revert "add prometheus adapter chart"

### DIFF
--- a/mirror.yaml
+++ b/mirror.yaml
@@ -19,7 +19,6 @@ mirrors:
     elasticsearch: https://charts.bitnami.com/bitnami
     # operator: https://operator.min.io/
     kube-prometheus-stack: https://prometheus-community.github.io/helm-charts
-    prometheus-adapter: https://prometheus-community.github.io/helm-charts
     kube-bench: https://charts.deliveryhero.io/
     kuberhealthy: https://kuberhealthy.github.io/kuberhealthy/helm-repos
     wordpress: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Reverts DaoCloud/public-helm-charts-mirror#30