### PR TITLE
remove submariner && metallb

### DIFF
--- a/mirror.yaml
+++ b/mirror.yaml
@@ -1,6 +1,5 @@
 mirrors:
   addon: # The Repo mirror to
-    submariner: https://submariner-io.github.io/submariner-charts/charts
     nvidia-device-plugin: https://nvidia.github.io/k8s-device-plugin
     hwameistor: http://hwameistor.io/hwameistor # Use by the DCE5 Installer, Do not Change
     drbd-adapter: http://hwameistor.io/hwameistor
@@ -38,7 +37,6 @@ mirrors:
     # Use by the DCE5 Installer, Do not Change
     chartmuseum: https://chartmuseum.github.io/charts
     kubean: https://kubean-io.github.io/kubean-helm-chart/
-    metallb: https://metallb.github.io/metallb
     minio: https://charts.min.io/
     harbor: https://helm.goharbor.io
     docker-registry: https://helm.twun.io


### PR DESCRIPTION
remove submariner && metallb

现在submariner 和 metallb 都通过 https://github.com/DaoCloud/dce-charts-repackage 制作的 chart 包发布，不需要从开源repo同步