### PR TITLE
move out hwameistor charts

### DIFF
--- a/mirror.yaml
+++ b/mirror.yaml
@@ -2,7 +2,8 @@ mirrors:
   addon: # The Repo mirror to
     submariner: https://submariner-io.github.io/submariner-charts/charts
     nvidia-device-plugin: https://nvidia.github.io/k8s-device-plugin
-    hwameistor: http://hwameistor.io/hwameistor # Use by the DCE5 Installer, Do not Change
+    # move to https://github.com/DaoCloud/storage-charts-repackage/tree/master/charts/hwameistor
+    # hwameistor: http://hwameistor.io/hwameistor # Use by the DCE5 Installer, Do not Change
     drbd-adapter: http://hwameistor.io/hwameistor
     metrics-server: https://kubernetes-sigs.github.io/metrics-server
   partner: []


### PR DESCRIPTION
Remove HwameiStor charts from here.

>Tips: HwameiStor charts used in `DCE5` will only be mirrored from https://github.com/DaoCloud/storage-charts-repackage/tree/master/charts/hwameistor